### PR TITLE
Removed jQuery dependency and added disposal callback

### DIFF
--- a/knockout-ace.js
+++ b/knockout-ace.js
@@ -9,7 +9,6 @@
   ko.bindingHandlers.ace = {
     init: function (element, valueAccessor, allBindingsAccessor, context) {
 
-      var init_arguments = arguments;
       var options = allBindingsAccessor().aceOptions || {};
       var modelValue = valueAccessor();
       var value = ko.utils.unwrapObservable(valueAccessor());

--- a/knockout-ace.js
+++ b/knockout-ace.js
@@ -35,6 +35,12 @@
       });
 
       instances_by_id[element.id] = editor;
+
+      // destroy the editor instance when the element is removed
+      ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+        editor.destroy();
+        delete instances_by_id[element.id];
+      });
     },
     update: function (element, valueAccessor, allBindingsAccessor, context) {
       var value = ko.utils.unwrapObservable(valueAccessor());

--- a/knockout-ace.js
+++ b/knockout-ace.js
@@ -2,7 +2,7 @@
 // https://github.com/SteveSanderson/knockout/wiki/Bindings---tinyMCE
 // Initial version by Ryan Niemeyer. Updated by Scott Messinger, Frederik Raabye, Thomas Hallock and Drew Freyling.
 
-(function($) {
+(function() {
   var instances_by_id = {} // needed for referencing instances during updates.
   , init_id = 0;           // generated id increment storage
 
@@ -13,7 +13,6 @@
       var options = allBindingsAccessor().aceOptions || {};
       var modelValue = valueAccessor();
       var value = ko.utils.unwrapObservable(valueAccessor());
-      var el = $(element);
 
       // Ace attaches to the element by DOM id, so we need to make one for the element if it doesn't have one already.
       if (!element.id) {
@@ -38,9 +37,8 @@
       instances_by_id[element.id] = editor;
     },
     update: function (element, valueAccessor, allBindingsAccessor, context) {
-      var el = $(element);
       var value = ko.utils.unwrapObservable(valueAccessor());
-      var id = el.attr('id');
+      var id = element.id;
 
       //handle programmatic updates to the observable
       // also makes sure it doesn't update it if it's the same.
@@ -55,4 +53,4 @@
       }
     }
   };
-}(jQuery));
+}());


### PR DESCRIPTION
Removes the jQuery dependency because it doesn't have added value here. Now others can use the binding without jQuery.

Adds a disposal callback that destroys the ace editor instance when the element, to which ace is bound, is removed from the DOM.
